### PR TITLE
initialize MongoDB setup folder

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,6 @@ services:
       - ${SERVER_PORT}:${SERVER_PORT}
     build:
       context: ./nodejs
-      dockerfile: Dockerfile
     env_file: .env
     volumes:
       - ./nodejs:/nodejs
@@ -32,8 +31,7 @@ services:
     ports:
       - ${DATABASE_PORT}:${DATABASE_PORT}
     build:
-      context: ./nodejs
-      dockerfile: Dockerfile
+      context: ./user_db
     env_file: .env
     volumes:
       - database-v:/data/db

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -31,6 +31,9 @@ services:
     container_name: ${DATABASE_HOST}
     ports:
       - ${DATABASE_PORT}:${DATABASE_PORT}
+    build:
+      context: ./nodejs
+      dockerfile: Dockerfile
     env_file: .env
     volumes:
       - database-v:/data/db

--- a/user_db/Dockerfile
+++ b/user_db/Dockerfile
@@ -1,0 +1,5 @@
+# initializes base image to MongoDB version 7.0.7
+FROM mongo:7.0.7
+
+# Expose the default MongoDB port
+EXPOSE 27017

--- a/user_db/Dockerfile
+++ b/user_db/Dockerfile
@@ -1,5 +1,5 @@
-# initializes base image to MongoDB version 7.0.7
-FROM mongo:7.0.7
+# initializes base image to MongoDB
+FROM mongo:latest
 
 # Expose the default MongoDB port
 EXPOSE 27017


### PR DESCRIPTION
adds Dockerfile and associated code to docker-compose file to properly initialize MongoDB into a container when first running the application.