### PR TITLE
screen adjustments for phones

### DIFF
--- a/front-end/src/App.css
+++ b/front-end/src/App.css
@@ -47,7 +47,7 @@
   transition: margin-left 0.5s ease;
 }
 
-@media (max-width: 900px) {
+@media (max-width: 600px) {
   .main-content {
     margin-left: 50px;
   }

--- a/front-end/src/components/PostComponent/PostComponent.css
+++ b/front-end/src/components/PostComponent/PostComponent.css
@@ -216,6 +216,14 @@
   transform: scale(0.98);
 }
 
+/* --- Post modal box realigning for Mobile Devices --- */
+@media (max-width: 600px) {
+  .modal-box {
+    margin-left: 60px;
+    align-items: center;
+  }
+}
+
 /* --- Modal Styles from File 2 --- */
 .modal-overlay {
   position: fixed;

--- a/front-end/src/pages/ProfilePage/ProfilePage.css
+++ b/front-end/src/pages/ProfilePage/ProfilePage.css
@@ -7,6 +7,13 @@
   flex-direction: column;
 }
 
+/* Profile page zoom adjustment for mobile devices */
+@media (max-width: 600px) {
+  body {
+    zoom: 0.65;
+  }
+}
+
 .profile-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Attempts to resize the screen if screen 600px or less -- the most consistent way I've found to ensure proper zoom is to rotate the screen between horizontal and vertical.

Also properly crops comment box and profile page when they are detected to be on mobile, but detection of profile page size is a little inconsistent.